### PR TITLE
Support settings import for non-default FS_METHOD definitions

### DIFF
--- a/admin/import/class-import-settings.php
+++ b/admin/import/class-import-settings.php
@@ -105,7 +105,12 @@ class WPSEO_Import_Settings {
 		$this->path = $this->upload_dir['basedir'] . DIRECTORY_SEPARATOR . 'wpseo-import' . DIRECTORY_SEPARATOR;
 
 		if ( ! isset( $GLOBALS['wp_filesystem'] ) || ! is_object( $GLOBALS['wp_filesystem'] ) ) {
-			WP_Filesystem();
+			$url = wp_nonce_url(
+				self_admin_url('admin.php?page=wpseo_tools&tool=import-export'),
+				'wpseo-import'
+			);
+			$creds = request_filesystem_credentials( esc_url_raw( $url ) );
+			WP_Filesystem( $creds );
 		}
 	}
 


### PR DESCRIPTION
## Summary
If WP_Filesystem() is called with empty $args, it won't pick up any FTP_* related constants defined in wp-config.php; amendend by generating $args with request_filesystem_credentials().

This PR can be summarized in the following changelog entry:

* Corrected WP_Filesystem() initialization call to support settings import for non-default FS_METHOD definitions

## Relevant technical choices:

To generate WP_Filesystem() initialization $args with request_filesystem_credentials().

## Test instructions

This PR can be tested by following these steps:

* Go to SEO > Tools > Import Settings and upload a settings.zip file
* Repeat with any working combination of FS_METHOD and FS_* constants

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #9610
